### PR TITLE
return maps as-is to form deeply nested JSON structures in message

### DIFF
--- a/src/lager_json_formatter.erl
+++ b/src/lager_json_formatter.erl
@@ -35,7 +35,10 @@ output({Key, Value}, Map, Message) ->
 get_data(Value, _) when is_list(Value); is_binary(Value) ->
   Value;
 get_data(message, Message) ->
-  to_binary(lager_msg:message(Message));
+  case lager_msg:message(Message) of
+    MapMsg when is_map(MapMsg) -> MapMsg;
+    Msg -> to_binary(Msg)
+  end;
 get_data(date, Message) ->
   {D, _} = lager_msg:datetime(Message),
   to_binary(D);


### PR DESCRIPTION
Hi @glejeune,
I realize this is a breaking change so I'm open to feedback for opting into this behavior if you want to preserve the old behavior by default. I imagine this is what consumers of a JSON formatter would want by default since presumably they chose JSON to do things like automate field extractions.